### PR TITLE
Make private member public to allow access to serialisation libraries

### DIFF
--- a/src/main/java/com/forgerock/cert/psd2/RoleOfPsp.java
+++ b/src/main/java/com/forgerock/cert/psd2/RoleOfPsp.java
@@ -55,7 +55,7 @@ import org.bouncycastle.asn1.*;
  */
 public class RoleOfPsp extends ASN1Object {
 
-    private Psd2Role role;
+    public Psd2Role role;
 
     public static RoleOfPsp getInstance(Object obj){
         if(obj instanceof RoleOfPsp){


### PR DESCRIPTION
- We were finding that some serialisation libs (such as minidev) were failing to serialise the RoleOfPsp class. This fixes that.