### PR TITLE
Bintray package name has changed to reflect the artifact Id

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,11 +109,11 @@
     </scm>
 
     <distributionManagement>
-        <repository>
-            <id>bintray-openbankingtoolkit-OpenBankingToolkit</id>
-            <name>OpenBankingToolkit EIDAS/PSD2</name>
-            <url>https://api.bintray.com/maven/openbanking-toolkit/OpenBankingToolKit/eidas-psd2-sdk/;publish=1</url>
-        </repository>
+       <repository>
+               <id>bintray-openbanking-toolkit-OpenBankingToolKit</id>
+               <name>openbanking-toolkit-OpenBankingToolKit</name>
+               <url>https://api.bintray.com/maven/openbanking-toolkit/OpenBankingToolKit/eidas-psd2-cert/;publish=1</url>
+       </repository>
     </distributionManagement>
 
     <repositories>


### PR DESCRIPTION
- The artifacts now live in the Bintray repo here;
https://dl.bintray.com/openbanking-toolkit/OpenBankingToolKit/com/forgerock/openbanking/eidas-psd2-cert/

Fix for https://github.com/OpenBankingToolkit/eidas-psd2-sdk/issues/32